### PR TITLE
Fixes to Code Adventures 2D Fluid Simulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ io_test/
 serial_test/
 serial_test_old/
 flsim/
+flsim_no_render/
 *.sbatch
 out/
 

--- a/ca_fluid_sim/fluid_sim.cpp
+++ b/ca_fluid_sim/fluid_sim.cpp
@@ -11,8 +11,7 @@
 
 #if TEST == 'A' // First test case from source
 
-// #define spawnCentre wash::Vec2D { 3.35, 0.51 }
-#define spawnCentre wash::Vec2D { 0.05, 0.51 }
+#define spawnCentre wash::Vec2D { 3.35, 0.51 }
 #define initialVelocity wash::Vec2D { 0.0, 0.0 }
 #define spawnSize wash::Vec2D { 7.0, 7.0 }
 #define jitterStr 0.025
@@ -28,8 +27,7 @@
 #define nearPressureMultiplier 18.0
 #define viscosityStrength 0.06
 #define boundsSize \
-    wash::Vec2D { 10.1, 17.1 }
-    // wash::Vec2D { 17.1, 9.3 }
+    wash::Vec2D { 17.1, 9.3 }
 
 #endif
 
@@ -278,7 +276,6 @@ void init() {
 }
 
 int main(int argc, char** argv) {
-    wash::set_precision("double");
     wash::set_influence_radius(smoothingRadius);
     wash::set_max_iterations(2000);
 

--- a/io/ascii.hpp
+++ b/io/ascii.hpp
@@ -7,18 +7,16 @@ namespace wash {
     class ASCIIWriter : public GenericFileWriter {
     public:
         ASCIIWriter() { /*std::cout << "ASCII Writer" << std::endl;*/ }
-
         ~ASCIIWriter() = default;
 
-        void begin_iteration(const size_t iterationc, const std::string path) override;
-        void write_iteration_attributes() override {}
-        void write_file_attributes() override {}
-        void write_particle() override {}
-        void finish_iteration() override {}
+        void write_iteration(const size_t iterationc, const std::string path) const override;
     };
 
     class ASCIIReader : public GenericFileReader {
     public:
         ASCIIReader() { /*std::cout << "ASCII Reader" << std::endl;*/ }
+        ~ASCIIReader() = default;
+
+        void read_iteration(const size_t iteration_number) const override;
     };
 }

--- a/io/hdf5.hpp
+++ b/io/hdf5.hpp
@@ -10,22 +10,18 @@
 namespace wash {
     class HDF5Writer : public GenericFileWriter {
     public:
-        HDF5Writer() { /*std::cout << "HDF5 Writer" << std::endl;*/
-        }
-
+        HDF5Writer() { /*std::cout << "HDF5 Writer" << std::endl;*/}
         ~HDF5Writer() = default;
 
-        void begin_iteration(const size_t iterationc, const std::string path) override;
-        void write_iteration_attributes() override {}
-        void write_file_attributes() override {}
-        void write_particle() override {}
-        void finish_iteration() override {}
+        void write_iteration(const size_t iterationc, const std::string path) const override;
     };
 
     class HDF5Reader : public GenericFileReader {
     public:
-        HDF5Reader() { /*std::cout << "HDF5 Reader" << std::endl;*/
-        }
+        HDF5Reader() { /*std::cout << "HDF5 Reader" << std::endl;*/}
+        ~HDF5Reader() = default;
+
+        void read_iteration(const size_t iteration_number) const override;
     };
 }
 

--- a/io/mock_io.hpp
+++ b/io/mock_io.hpp
@@ -27,16 +27,12 @@ namespace wash {
 
     class GenericFileWriter {
     public:
-        virtual void begin_iteration(const size_t iterationc, const std::string path) = 0;
-        virtual void write_iteration_attributes() = 0;
-        virtual void write_file_attributes() = 0;
-        virtual void write_particle() = 0;
-        virtual void finish_iteration() = 0;
+        virtual void write_iteration(const size_t iterationc, const std::string path) const = 0;
     };
 
     class GenericFileReader {
     public:
-        GenericFileReader() {}
+        virtual void read_iteration(const size_t iteration_number) const = 0;
     };
 
     /**

--- a/io/read_ascii.cpp
+++ b/io/read_ascii.cpp
@@ -10,4 +10,22 @@
 
 #include "ascii.hpp"
 
-namespace wash {}
+namespace wash {
+    void ASCIIReader::read_iteration(const size_t iteration_number) const {
+
+    }
+}
+
+/*
+Read in header line:
+id,pos[dim],vel[dim],acc[dim],p,m,h,forces[dim/scalar]
+
+can tell `dim` from `name_{}`
+
+for each line go through and get the particle data
+- split at ",", parse as doubles, etc.
+- create particle and add it to the simulation
+
+Smoothing Length from a `h` value?
+Max Iterations set by user in program
+*/

--- a/io/read_hdf5.cpp
+++ b/io/read_hdf5.cpp
@@ -15,6 +15,10 @@
 #include "hdf5.hpp"
 
 #ifdef WASH_HDF5_SUPPORT
-namespace wash {}  // namespace wash
+namespace wash {
+    void HDF5Reader::read_iteration(const size_t iteration_number) const {
+
+    }
+}  // namespace wash
 
 #endif

--- a/io/write_ascii.cpp
+++ b/io/write_ascii.cpp
@@ -13,7 +13,7 @@
 #include "ascii.hpp"
 
 namespace wash {
-    void ASCIIWriter::begin_iteration(const size_t iterationc, const std::string path) {
+    void ASCIIWriter::write_iteration(const size_t iterationc, const std::string path) const {
         std::string fpath = path + "." + string_format("%04d", iterationc) + ".txt";
 
         size_t idx = 0;

--- a/io/write_hdf5.cpp
+++ b/io/write_hdf5.cpp
@@ -22,7 +22,7 @@
 #ifdef WASH_HDF5_SUPPORT
 
 namespace wash {
-    void HDF5Writer::begin_iteration(const size_t iterationc, const std::string path) {
+    void HDF5Writer::write_iteration(const size_t iterationc, const std::string path) const {
 
         std::string fpath = path + "." + string_format("%04d", iterationc) + ".h5";
 

--- a/wash_mockapi.cpp
+++ b/wash_mockapi.cpp
@@ -160,7 +160,6 @@ namespace wash {
 
         std::cout << "Output Path " << output_path << std::endl;
 
-        // auto awriter = get_file_writer("ascii");
         auto fwriter = get_file_writer("hdf5");
 
         // // Add forces to each particle's force map

--- a/wash_mockapi.cpp
+++ b/wash_mockapi.cpp
@@ -161,7 +161,7 @@ namespace wash {
         std::cout << "Output Path " << output_path << std::endl;
 
         // auto awriter = get_file_writer("ascii");
-        auto hwriter = get_file_writer("hdf5");
+        auto fwriter = get_file_writer("hdf5");
 
         // // Add forces to each particle's force map
         // for (Particle& p : particles) {
@@ -181,8 +181,10 @@ namespace wash {
 
         init_kernel_ptr();
 
+        fwriter->write_iteration(0, output_path);
+
         for (uint64_t iter = 0; iter < max_iterations; iter++) {
-            std::cout << "Iteration " << iter << std::endl;
+            // std::cout << "Iteration " << iter << std::endl;
 
             // Compute densities
             // this has to be done before force kernel for e.g. fluid sim
@@ -199,7 +201,7 @@ namespace wash {
                 // std::cout << "DENSITY particle " << i++ << " with " << neighbors.size() << " neighbors" << std::endl;
                 d_kernel(p, neighbors);
             }
-            
+            #pragma omp barrier
 
             // Compute forces
             //size_t i = 0;
@@ -220,6 +222,7 @@ namespace wash {
                 // std::cout << " px=" << *p.get_force_vector("pressure")[0] << " py=" <<
                 // *p.get_force_vector("pressure")[1] << std::endl;
             }
+            #pragma omp barrier 
 
             // Update the positions (and derivatives) of each particle
             i = 0;
@@ -230,9 +233,11 @@ namespace wash {
                 // std::cout << " rho=" << p.get_density() << std::endl;
                 update_kernel_ptr(p);
             }
+            #pragma omp barrier 
 
-            hwriter->begin_iteration(iter, output_path);
+            fwriter->write_iteration(iter+1, output_path);
         }
+        std::cout << "Finished All Iterations" << std::endl;
     }
 
     const std::vector<std::string>& sim_get_forces_scalar() {


### PR DESCRIPTION
- Attempts to fix issue with simulation becoming chaotic seemingly randomly
- Uses predicted position in the `pos` parameter, with the actual position stored in vector parameter `position`.
- This is to ensure that NN calculations are done using the predicted position, and any distance based kernel functions use the predicted positions. 
- Prediction is done after the update of one iteration before the density calculation of the next 
- Includes some refactoring changes to the IO writing, introduces a 0th iteration dump for the initialisation conditions and logs more info like timestep and first 5 particle positions for helping track the randomness (since positions should be fixed between iterations because of the seeded RNG). 